### PR TITLE
Added lib-FIM to the package index

### DIFF
--- a/package_index.json
+++ b/package_index.json
@@ -29,5 +29,10 @@
     "installers": [
       "def"
     ]
+  },
+  "lib-FIM": {
+    "name": "lib-fim",
+    "author": "Nick Anderson",
+    "zip": "https://github.com/nickanderson/cfengine-file_integrity_monitoring/archive/master.zip"
   }
 }


### PR DESCRIPTION
This library makes it easy to monitor files for change.
Simply tag a variable that contains the path to the file you want to monitor
with `FIM=all_changes`.

For example:

```
vars:
  "fstab" string => "/etc/fstab", meta => { "FIM=all_changes" };
```